### PR TITLE
Update Javascript.md

### DIFF
--- a/Javascript.md
+++ b/Javascript.md
@@ -256,8 +256,6 @@ switch(1 + 3) {
 }
 ```
 
-> **HISE** (and its underlying JavascriptEngine from **JUCE**) does not support the switch statement. I left this paragraph in because it may be added it the future.
-
 ## Objects
 JavaScript objects can be thought of as simple collections of name-value pairs. As such, they are similar to:
 


### PR DESCRIPTION
Removing mention of switch cases being unsupported by HISE/JUCE.

AFAIK this isn't an issue anymore, switch() is mentioned in Tutorial IV and I've seen it compile with my own eyes.